### PR TITLE
choose the color pallete from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The following flags are available, and they are all optional (if you ignore them
 - **-l or --limit:** how small a language as a percentage of the whole must be to be excluded. Default is 1. *Example: `statistics -l 5` (if it takes up less than 5 percent, it will be grouped with other)*
 - **-m or --maximum:** the maximum number of unique languages to show (excluding 'Other'). Default is 8. *Example: `statistics -m 3` will show at most 3 other languages in addition to 'Other'*
 - **-e or --exclude:** which file extensions to exclude when searching for files and creating the image. These files will be ignored and will not affect the total percentage or show up. You can specify multiple. *Example: `statistics -e .ipynb .css .html`*
+- **-c or --colors:** which hex colors to be used for creating the image. Applied left to right from highest perentage to lowest. If no colors are provided, or too few, the YAML will be used or another strategy to pick the remainder of the colors. *Example: `statistics -c ffb6c1 00ff00`*
 
 The above flags can be used in any order, combined, and are completely optional (`statistics --type png -l 5 -m 3 --depth 4 -e .ipynb`). If you are ever in doubt you can run `statistics -h` to get a help output on console reminding you of the flags.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following flags are available, and they are all optional (if you ignore them
 - **-l or --limit:** how small a language as a percentage of the whole must be to be excluded. Default is 1. *Example: `statistics -l 5` (if it takes up less than 5 percent, it will be grouped with other)*
 - **-m or --maximum:** the maximum number of unique languages to show (excluding 'Other'). Default is 8. *Example: `statistics -m 3` will show at most 3 other languages in addition to 'Other'*
 - **-e or --exclude:** which file extensions to exclude when searching for files and creating the image. These files will be ignored and will not affect the total percentage or show up. You can specify multiple. *Example: `statistics -e .ipynb .css .html`*
-- **-c or --colors:** which hex colors to be used for creating the image. Applied left to right from highest perentage to lowest. If no colors are provided, or too few, the YAML will be used or another strategy to pick the remainder of the colors. *Example: `statistics -c ffb6c1 00ff00`*
+- **-c or --colors:** which hex colors to be used for creating the image. Applied left to right from highest percentage to lowest. If no colors are provided, or too few, the YAML will be used or another strategy to pick the remainder of the colors. *Example: `statistics -c ffb6c1 00ff00`*
 
 The above flags can be used in any order, combined, and are completely optional (`statistics --type png -l 5 -m 3 --depth 4 -e .ipynb`). If you are ever in doubt you can run `statistics -h` to get a help output on console reminding you of the flags.
 

--- a/language_statistics/colorbar.py
+++ b/language_statistics/colorbar.py
@@ -11,7 +11,7 @@ def hex_to_rgb(code):
     return tuple(int(hexf[i : i + hlen // 3], 16) for i in range(0, hlen, hlen // 3))
 
 
-def draw_statistics(extension: str, other: int, maximum: int, depth: int, exclude: list):
+def draw_statistics(extension: str, other: int, maximum: int, depth: int, exclude: list, colors: list):
     data = language_bytes.read_file_data(depth, exclude)
 
     bytesum = 0
@@ -81,6 +81,7 @@ def draw_statistics(extension: str, other: int, maximum: int, depth: int, exclud
     ctx.set_source_rgb(1, 1, 1)
     ctx.fill()
 
+    color_index = 0
     x, text_x, text_y, text_height = 3, 25, 60, 0
     for language in language_percentages:
 
@@ -100,7 +101,11 @@ def draw_statistics(extension: str, other: int, maximum: int, depth: int, exclud
 
         x += round(language_percentages[language] * 4)
 
-        code = data[language][1][1:]
+        if (color_index <= len(colors) -1):
+            code = colors[color_index]
+            color_index += 1
+        else:
+            code = data[language][1][1:]
         output = hex_to_rgb(code)
 
         ctx.set_source_rgb(output[0] / 255, output[1] / 255, output[2] / 255)

--- a/language_statistics/statistics.py
+++ b/language_statistics/statistics.py
@@ -51,12 +51,19 @@ def main():
         required = False
     )
 
+    parser.add_argument(
+        '-c',
+        '--colors',
+        nargs = '*',
+        default = '',
+        help = 'List of hex colors to use. Default is none, indicating to use the YAML colors.',
+        required = False
+    )
     args = parser.parse_args()
 
     # try:
     print("Creating file with language bar for current directory...")
-
-    colorbar.draw_statistics(args.type, args.limit, args.maximum, args.depth - 1, args.exclude)
+    colorbar.draw_statistics(args.type, args.limit, args.maximum, args.depth - 1, args.exclude, args.colors)
     print(f"Completed process, image can be found at {os.getcwd()}/output.{args.type}!")
     # except:
     #     print("[ERROR] You have entered one or more of your arguments incorrectly!")


### PR DESCRIPTION
This pr is for a color palette switch for the command line. This allows for adjacent colors to always have good contrast and an easier than yaml way to impose a color scheme. The trade-off being inconsistent coloring of file types from project to project. If the number of bins is greater than the number of colors provided previous methodology will be used for the remaining bins.